### PR TITLE
bump upper bound on time dependency

### DIFF
--- a/rss.cabal
+++ b/rss.cabal
@@ -43,7 +43,7 @@ library
     build-depends: time       >= 1.1.2 && < 1.5
                  , old-locale >= 1.0   && < 1.1
   else
-    build-depends: time       >= 1.5   && < 1.9
+    build-depends: time       >= 1.5   && < 1.10
 
   if flag(network-uri)
     build-depends: network-uri >= 2.6 && < 2.7


### PR DESCRIPTION
`time`'s changelog suggests nothing breaking since `time-1.8` in the functions used by `rss`.